### PR TITLE
init_unfold: Prefer unfold/lib over EEGlab/plugin

### DIFF
--- a/init_unfold.m
+++ b/init_unfold.m
@@ -4,6 +4,14 @@ fprintf('\nStarting unfold toolbox.\nAdding subfolders and other toolboxes to pa
 projectFolder  = fileparts(which('init_unfold.m'));
 scriptDir = fullfile(projectFolder,'src');
 
+if ~exist('eeg_checkset','file')
+    try
+        eeglab redraw
+    catch
+        warning('%s(): EEGLAB could not be found in your path. Please add it to your path. Otherwise, you should be fine EXCEPT if you want to use uf_epoch() (for massive univariate modeling without overlap correction) which requires EEGLAB.\n',mfilename)
+        addpath(fullfile(projectFolder,'lib','eeglab'))
+    end
+end
 
 addpath(genpath(scriptDir))
 addpath(fullfile(projectFolder,'lib','erplab'))
@@ -15,15 +23,6 @@ addpath(fullfile(projectFolder,'lib','ept_TFCE','TFCE','Dependencies'))
 addpath(genpath(fullfile(projectFolder,'lib','eegvis','topo_butter')))
 
 addpath(fullfile(projectFolder,'lib','glmnet_matlab'))
-
-if ~exist('eeg_checkset','file')
-    try
-        eeglab redraw
-    catch
-        warning('%s(): EEGLAB could not be found in your path. Please add it to your path. Otherwise, you should be fine EXCEPT if you want to use uf_epoch() (for massive univariate modeling without overlap correction) which requires EEGLAB.\n',mfilename)
-        addpath(fullfile(projectFolder,'lib','eeglab'))
-    end
-end
 
 if ~exist('gramm','file')
     warning('%s():\ngramm could not be found. Did you run "git submodule update --init" to initialize submodules?\n',mfilename)


### PR DESCRIPTION
When EEGlab has not been launched previously, launching it via `eeglab redraw` in `init_unfold.m` automatically loads all installed eeglab-extensions. This is problematic for (at least) `uf_continuousArtifactDetect.m`, which depends on the modified version of `basicrap.m` in `unfold/lib/erplab/` and fails if the version in `eeglab/plugins/erplab/` has a higher preference. Adding the paths to `unfold/lib/*` after (instead of before) launching eeglab solves this problem and makes sure the included libs always have higher preference.