### PR TITLE
uf_glmfit: adjust atol argument for par-lsmr

### DIFF
--- a/src/uf_toolbox/uf_glmfit.m
+++ b/src/uf_toolbox/uf_glmfit.m
@@ -184,7 +184,7 @@ elseif strcmp(cfg.method,'par-lsmr')
         
         fprintf('\nsolving electrode %d (of %d electrodes in total)',e,length(cfg.channel))
         % use iterative solver for least-squares problems (lsmr)
-        [beta(:,e),ISTOP,ITN] = lsmr(parXdc.Value,parData.Value(:,e),[],10^-10,10^-10,[],cfg.lsmriterations); % ISTOP = reason why algorithm has terminated, ITN = iterations
+        [beta(:,e),ISTOP,ITN] = lsmr(parXdc.Value,parData.Value(:,e),[],10^-8,10^-8,[],cfg.lsmriterations); % ISTOP = reason why algorithm has terminated, ITN = iterations
         if ISTOP == 7
             warning(['The iterative least squares did not converge for channel ',num2str(e), ' after ' num2str(ITN) ' iterations. You can either try to increase the number of iterations using the option ''lsmriterations'' or it might be, that your model is highly collinear and difficult to estimate. Check the designmatrix EEG.unfold.X for collinearity.'])
         elseif ITN == cfg.lsmriterations


### PR DESCRIPTION
The `atol` argument for the `par-lsmr` cas was slightly different from the serial "lsmr" case.